### PR TITLE
Fix compilation error when neither xsel nor xclip is found

### DIFF
--- a/src/text.lisp
+++ b/src/text.lisp
@@ -14,7 +14,8 @@ Return nil if COMMAND is not found anywhere."
   "pbcopy"
   #+(and :unix (:not :darwin))
   (or (executable-find "xclip")
-      (executable-find "xsel")))
+      (executable-find "xsel")
+      ""))
 
 (defvar *clipboard-out-command*
   #+(or darwin macosx)


### PR DESCRIPTION
This simple fix should do it.

This highlights one shortcoming however: the xclip / xsel executables are not really found dynamically, i.e. if they are installed after trivial-clipboard is loaded, they won't be found.

A solution to this would be to turn *clipboard-in/out-command* into functions.  What do you think?