### PR TITLE
Make `text` a `setf`-able method.

### DIFF
--- a/src/text.lisp
+++ b/src/text.lisp
@@ -61,7 +61,7 @@ Return nil if COMMAND is not found anywhere."
         (error 'not-installed
                :programs (clipboard-programs #'get-copy-command)))))
 
-(defun text (&optional data)
+(defmethod text (&optional data)
   "If DATA is STRING, it is set to the clipboard. An ERROR is
 signalled if the copy failed.
 
@@ -80,3 +80,14 @@ copy failed, it returns NIL instead."
       (get-text-on-win32)
       #+(not os-windows)
       (paste)))))
+
+(defmethod (setf text) ((data string) &optional data-unused)
+  "If DATA is STRING, it is set to the clipboard.
+
+An ERROR is signalled if the copy failed."
+  (declare (ignore data-unused))
+  #+os-windows
+  (set-text-on-win32 data)
+  #+(not os-windows)
+  (copy data)
+  data)


### PR DESCRIPTION
This turns `text` into a method, thus making it:
- Advisable with `:before`, `:after`, and `:around` qualifier methods.
- Specializeable over types other than strings (arrays? images? objects? -- the possibilities are endless :D)
- Type-checking (well, only for the `seft`-method, but there's not much need in type-checking there ¯\\\_(ツ)_/¯)
- `seft`-able (would work for a function too, actually, but method gives us typing and other niceties for free).

I've tried to preserve backwards-compatibility, although I have initially tried to remove the `&optional data` too, so that it's even nicer of an API. However, I don't want to break anyone's workflows without an explicit version bump. Thus, @snmsts, are you willing to release a new version with method-based `text` and without the optional `data` argument?