### PR TITLE
Replace ad-hoc user32 loading

### DIFF
--- a/src/windows.lisp
+++ b/src/windows.lisp
@@ -4,7 +4,10 @@
 
 (cl:in-package :trivial-clipboard)
 
-(load-foreign-library '(:default "User32"))
+(define-foreign-library user32
+  (t (:default "user32")))
+
+(use-foreign-library user32)
 
 ;; Flags
 (eval-when (:compile-toplevel :load-toplevel :execute)


### PR DESCRIPTION
This is needed for other libraries like `deploy`.

Ref https://github.com/Shinmera/deploy/issues/22#issuecomment-1493929699