### PR TITLE
Improve find-command mechanism

### DIFF
--- a/src/text.lisp
+++ b/src/text.lisp
@@ -25,7 +25,7 @@ Return nil if COMMAND is not found anywhere."
      ("xclip" "-in" "-selection" "clipboard")
      ("xclip" "-out" "-selection" "clipboard"))
     (:xsel
-     ,(lambda () (and (executable-find "xclip") (x-session-p)))
+     ,(lambda () (and (executable-find "xsel") (x-session-p)))
      ("xsel" "--input" "--clipboard")
      ("xsel" "--output" "--clipboard")))
   "A list, each element being of the form (clibpoard-method predicate

--- a/src/text.lisp
+++ b/src/text.lisp
@@ -17,9 +17,9 @@ Return nil if COMMAND is not found anywhere."
 
 (defparameter *clipboard-commands*
   #+(or darwin macosx)
-  '((:mac
-     ("pbcopy" (lambda () (executable-find "pbcopy")))
-     ("pbpaste" (lambda () (executable-find "pbpaste")))))
+  `((:mac
+     ("pbcopy" ,(lambda () (executable-find "pbcopy")))
+     ("pbpaste" ,(lambda () (executable-find "pbpaste")))))
   #-(or darwin macosx)
   `((:wayland
      (("wl-copy")

--- a/src/text.lisp
+++ b/src/text.lisp
@@ -28,7 +28,7 @@ Return nil if COMMAND is not found anywhere."
      ,(lambda () (and (executable-find "xsel") (x-session-p)))
      ("xsel" "--input" "--clipboard")
      ("xsel" "--output" "--clipboard")))
-  "A list, each element being of the form (clibpoard-method predicate
+  "A list, each element being of the form (clipboard-method predicate
 copy-command paste-command).")
 
 (defun clipboard-programs (fn)


### PR DESCRIPTION
Improve find-command mechanism by providing more detailed predicates to select clipboard commands

Tentative fix for #16 . I added the possibility for more precise availability checking for clipboard commands. The code ends up a bit more complex though (because availability predicates are now included in *clipboard-commands*), so I'm happy to get feedback about it. Tests are passing on my end. 